### PR TITLE
Manage amount as double when scanning invoice, fix issue291

### DIFF
--- a/NEMWallet/Application/Invoice/InvoiceScannerViewController.swift
+++ b/NEMWallet/Application/Invoice/InvoiceScannerViewController.swift
@@ -56,7 +56,7 @@ class InvoiceScannerViewController: UIViewController {
             let destinationViewController = segue.destination as! TransactionSendViewController
             let invoiceJsonData = sender as! JSON
             destinationViewController.recipientAddress = invoiceJsonData["addr"].stringValue
-            destinationViewController.amount = Double(invoiceJsonData["amount"].intValue / 1000000)
+            destinationViewController.amount = Double(invoiceJsonData["amount"].intValue) / Double(1000000)
             destinationViewController.message = invoiceJsonData["msg"].stringValue
 
         default:


### PR DESCRIPTION
`invoiceJsonData["amount"].intValue / 1000000` is handled as integer, so decimal point truncation occured.
This PR fixes #291 . Please review 😄 