### PR TITLE
Fix issue #301 - App crashes when save QR

### DIFF
--- a/NEMWallet/Assets/Property Lists/Info.plist
+++ b/NEMWallet/Assets/Property Lists/Info.plist
@@ -43,7 +43,7 @@
 	<string></string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
-	<key>NSPhotoLibraryUsageDescription</key>
+	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Allow access to your photo library to save QR code images</string>
 	<key>UIBackgroundModes</key>
 	<array>


### PR DESCRIPTION
- Due to new Cocoa key introduced in iOS 11 -
  NSPhotoLibraryAddUsageDescription